### PR TITLE
Added scales

### DIFF
--- a/src/modules/scatterPlot.js
+++ b/src/modules/scatterPlot.js
@@ -1,7 +1,8 @@
 (function (context) {
   const module = context.d3Viz
   const width = 500
-  const height = 100
+  const height = 300
+  const padding = 20
   var dataset = [
     [5, 20],
     [480, 90],
@@ -12,7 +13,8 @@
     [475, 44],
     [25, 67],
     [85, 21],
-    [220, 88]
+    [220, 88],
+    [600, 150]
   ]
 
   const drawScatterPlot = function () {
@@ -25,18 +27,28 @@
       .attr('width', width)
       .attr('height', height)
 
+    const xScale = context.d3.scaleLinear()
+      .domain([0, context.d3.max(dataset, function (d) { return d[0] })])
+      .range([padding, width - padding])
+    const yScale = context.d3.scaleLinear()
+      .domain([0, context.d3.max(dataset, function (d) { return d[1] })])
+      .range([height - padding, padding])
+    const rScale = context.d3.scaleLinear()
+      .domain([0, context.d3.max(dataset, function (d) { return d[1] })])
+      .range([0, 5])
+
     svg.selectAll('circle')
       .data(dataset)
       .enter()
       .append('circle')
       .attr('cx', function (d, index) {
-        return d[0]
+        return xScale(d[0])
       })
       .attr('cy', function (d, index) {
-        return d[1] + 10
+        return yScale(d[1])
       })
       .attr('r', function (d, index) {
-        return Math.sqrt(height - d[1])
+        return rScale(d[1])
       })
       // drawing relative fill according to max data
       .attr('fill', 'black')
@@ -49,10 +61,10 @@
         return `${d[0]}, ${d[1]}`
       })
       .attr('x', function (data, index) {
-        return data[0]
+        return xScale(data[0])
       })
       .attr('y', function (data, index) {
-        return data[1]
+        return yScale(data[1])
       })
       .attr('font-family', 'sans-serif')
       .attr('font-size', '11px')


### PR DESCRIPTION
Input Domain -> Output Scale

Using scale we can create output values corresponding to our actual svg size.

[Scales by Scott Murray](http://alignedleft.com/tutorials/d3/scales)

![scatterplot](https://user-images.githubusercontent.com/2618932/26907796-a1ea87e8-4c28-11e7-8ce3-8517651f86c2.PNG)
